### PR TITLE
Add backlog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fuzz-roadmap",
-	"version": "1.2.4",
+	"version": "1.3.0",
 	"description": "A roadmapping tool that lets you forget about time estimate and focus on what matters",
 	"author": "Adrien D. Ahlqvist",
 	"bugs": "https://github.com/Armitage35/fuzzy-roadmap/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "fuzz-roadmap",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "A roadmapping tool that lets you forget about time estimate and focus on what matters",
 	"author": "Adrien D. Ahlqvist",
 	"bugs": "https://github.com/Armitage35/fuzzy-roadmap/issues",


### PR DESCRIPTION
This PR fixes GH-24

## Quick description

This PR adds: 
- [ ] a backlog to show epics all epics in a list format.
- [ ] an updated demo
- [ ] an option to say whether or not an epic is in the roadmap or just in the backlog

Checklist

- [ ] Automated test coverage
- [ ] Tested on Firefox
- [ ] Tested on Chrome
- [ ] Tested on weird screen sizes

### Screenshot

<!-- ![GitHub Logo](/images/logo.png) -->
